### PR TITLE
Migrate login/logout to identity provider

### DIFF
--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,0 +1,27 @@
+function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop().split(';').shift();
+  return '';
+}
+
+const form = document.getElementById('login-form');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData(form);
+  const data = Object.fromEntries(formData);
+  const resp = await fetch('/api/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCookie('csrftoken')
+    },
+    body: JSON.stringify(data),
+    credentials: 'same-origin'
+  });
+  if (resp.ok) {
+    window.location.href = '/';
+  } else {
+    document.getElementById('login-error').innerText = 'Invalid credentials.';
+  }
+});

--- a/static/js/logout.js
+++ b/static/js/logout.js
@@ -1,0 +1,16 @@
+function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop().split(';').shift();
+  return '';
+}
+
+fetch('/api/logout', {
+  method: 'POST',
+  headers: {
+    'X-CSRFToken': getCookie('csrftoken')
+  },
+  credentials: 'same-origin'
+}).then(() => {
+  // optional success handling
+});

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -17,62 +17,25 @@ CIELO for their cloud operations.
 <p class="text-muted mb-4">Enter your username and password to access CIELO dashboard.</p>
 
 <!-- form -->
-<form method="post">
+<form id="login-form">
     {% csrf_token %}
-    
-    {% if form.non_field_errors %}
-        <div class="alert alert-danger" role="alert">
-            {% for error in form.non_field_errors %}
-                {{ error }}
-            {% endfor %}
-        </div>
-    {% endif %}
-    
     <div class="mb-2">
-        <label for="{{ form.username.id_for_label }}" class="form-label">{{ form.username.label }}</label>
-        <input class="form-control {% if form.username.errors %}is-invalid{% endif %}" 
-               type="text" 
-               id="{{ form.username.id_for_label }}" 
-               name="{{ form.username.name }}"
-               value="{{ form.username.value|default:'' }}"
-               required 
-               placeholder="Enter your username">
-        {% if form.username.errors %}
-            <div class="invalid-feedback">
-                {% for error in form.username.errors %}{{ error }}{% endfor %}
-            </div>
-        {% endif %}
+        <label for="id_username" class="form-label">Username</label>
+        <input type="text" id="id_username" name="username" class="form-control" required>
     </div>
-    
+
     <div class="mb-2">
-        <label for="{{ form.password.id_for_label }}" class="form-label">{{ form.password.label }}</label>
+        <label for="id_password" class="form-label">Password</label>
         <div class="input-group input-group-merge">
-            <input type="password" 
-                   id="{{ form.password.id_for_label }}" 
-                   name="{{ form.password.name }}"
-                   class="form-control {% if form.password.errors %}is-invalid{% endif %}" 
-                   placeholder="Enter your password"
-                   required>
+            <input type="password" id="id_password" name="password" class="form-control" required>
             <div class="input-group-text" data-password="false">
                 <span class="password-eye"></span>
             </div>
         </div>
-        {% if form.password.errors %}
-            <div class="invalid-feedback">
-                {% for error in form.password.errors %}{{ error }}{% endfor %}
-            </div>
-        {% endif %}
     </div>
-    
-    <div class="mb-3">
-        <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="remember-me" name="remember_me">
-            <label class="form-check-label" for="remember-me">
-                Remember me
-            </label>
-        </div>
-    </div>
-    
+
+    <div id="login-error" class="text-danger mb-2"></div>
+
     <div class="d-grid text-center">
         <button class="btn btn-primary" type="submit">Log In</button>
     </div>
@@ -83,4 +46,8 @@ CIELO for their cloud operations.
 <footer class="footer footer-alt">
     <p class="text-muted">Need help? Contact your administrator.</p>
 </footer>
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/login.js' %}"></script>
 {% endblock %}

--- a/templates/users/logout.html
+++ b/templates/users/logout.html
@@ -45,3 +45,7 @@ See you again soon!
     <p class="text-muted">Back to <a href="/users/login/" class="text-primary fw-medium ms-1">Sign In</a></p>
 </footer>
 {% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/logout.js' %}"></script>
+{% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -1,43 +1,20 @@
 from django.shortcuts import render, redirect
-from django.contrib.auth import login, logout, authenticate
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
+from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth import update_session_auth_hash
 from django.contrib import messages
-from django.urls import reverse_lazy
 
 
 def user_login(request):
-    """
-    User login view that displays login form and handles authentication.
-    """
+    """Render the login page. Authentication is handled via API calls."""
     if request.user.is_authenticated:
         return redirect('index')
-    
-    if request.method == 'POST':
-        form = AuthenticationForm(request, data=request.POST)
-        if form.is_valid():
-            username = form.cleaned_data.get('username')
-            password = form.cleaned_data.get('password')
-            user = authenticate(username=username, password=password)
-            if user is not None:
-                login(request, user)
-                messages.success(request, f'Welcome back, {user.username}!')
-                next_url = request.GET.get('next', 'index')
-                return redirect(next_url)
-            else:
-                messages.error(request, 'Invalid username or password.')
-    else:
-        form = AuthenticationForm()
-    
-    return render(request, 'users/login.html', {'form': form})
+
+    return render(request, 'users/login.html')
 
 
 def user_logout(request):
-    """
-    User logout view that logs out the user and displays confirmation.
-    """
-    logout(request)
+    """Display logout confirmation page. Session termination handled via API."""
     messages.success(request, 'You have been successfully logged out.')
     return render(request, 'users/logout.html')
 


### PR DESCRIPTION
## Summary
- switch login page to use JS fetch to /api/login
- call identity provider logout from a script
- remove Django AuthenticationForm usage
- add login/logout JavaScript handlers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683c15eb18d88330b7937e4e225c71ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added asynchronous login and logout functionality, allowing users to log in and out without page reloads.
- **Refactor**
	- Simplified login and logout forms to use static HTML and client-side handling.
	- Moved authentication logic from the server to API endpoints, with pages now rendering only the relevant forms or confirmations.
- **Style**
	- Updated login error display to show messages dynamically within the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->