### PR TITLE
Add SSO session checks and docs

### DIFF
--- a/cielo_frontend/static/js/logout.js
+++ b/cielo_frontend/static/js/logout.js
@@ -11,6 +11,7 @@ fetch(`${window.IDENTITY_BASE}/logout`, {
     'X-CSRFToken': getCookie('csrftoken')
   },
   credentials: 'same-origin'
-}).then(() => {
-  // optional success handling
+}).finally(() => {
+  document.cookie = 'sessionid=; Max-Age=0; path=/; domain=.cielo.test';
+  window.location.href = '/users/login/';
 });

--- a/cielo_frontend/static/js/session.js
+++ b/cielo_frontend/static/js/session.js
@@ -1,0 +1,17 @@
+(async function() {
+  try {
+    const resp = await fetch(`${window.IDENTITY_BASE}/session`, {
+      credentials: 'include'
+    });
+    if (!resp.ok) {
+      window.location.href = '/users/login/';
+      return;
+    }
+    const data = await resp.json();
+    if (!data || data.authenticated !== true) {
+      window.location.href = '/users/login/';
+    }
+  } catch (err) {
+    window.location.href = '/users/login/';
+  }
+})();

--- a/cielo_frontend/templates/base_auth_fluid.html
+++ b/cielo_frontend/templates/base_auth_fluid.html
@@ -20,6 +20,9 @@
 
     <!-- Theme Config Js -->
     <script src="{% static 'material_theme/js/config.js' %}"></script>
+    <script>
+        window.IDENTITY_BASE = 'http://identity.cielo.test';
+    </script>
 
     {% block extra_head %}{% endblock %}
 </head>

--- a/cielo_frontend/templates/base_material.html
+++ b/cielo_frontend/templates/base_material.html
@@ -21,7 +21,10 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
 		<!-- Theme Config Js -->
-		<script src="{% static 'material_theme/js/config.js' %}"></script>
+                <script src="{% static 'material_theme/js/config.js' %}"></script>
+        <script>
+            window.IDENTITY_BASE = 'http://identity.cielo.test';
+        </script>
 
         <!-- Custom styles for multi-level sidebar -->
         <style>
@@ -475,6 +478,7 @@
 
         <!-- App js -->
         <script src="{% static 'material_theme/js/app.min.js' %}"></script>
+        <script src="{% static 'js/session.js' %}"></script>
 
         {% block extra_js %}{% endblock %}
         

--- a/cielo_frontend/templates/users/change_password.html
+++ b/cielo_frontend/templates/users/change_password.html
@@ -99,3 +99,7 @@ Thank you for keeping your account secure.
     <p class="text-muted">Return to <a href="/users/login/" class="text-primary fw-medium ms-1">Sign In</a></p>
 </footer>
 {% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/session.js' %}"></script>
+{% endblock %}

--- a/docs/CieloFrontEndAuthenticationFlow.md
+++ b/docs/CieloFrontEndAuthenticationFlow.md
@@ -8,7 +8,7 @@ This document describes how the CieloFrontend authenticates a user via the Cielo
    The user visits the login page rendered by Django at `/users/login/` (template: `templates/users/login.html`).
 
 2. **JavaScript-Driven API Call**
-   A JavaScript file (`static/js/login.js`) captures the login form submission. It prevents the default form behavior and sends a `POST` request to `/api/login`, containing the username and password as JSON. The CSRF token is included in the request header.
+   A JavaScript file (`static/js/login.js`) captures the login form submission. It prevents the default form behavior and sends a `POST` request to `http://identity.cielo.test/login`, containing the username and password as JSON. The CSRF token is included in the request header.
 
 3. **Backend Authentication**
    The `/api/login` endpoint is proxied or routed to the `CieloIdentityProvider`, where Django's `AuthenticationService` verifies credentials. If valid, Django's `login()` method creates a session and returns user details.
@@ -19,13 +19,19 @@ This document describes how the CieloFrontend authenticates a user via the Cielo
 ### Logout Flow
 
 1. **Logout Request**
-   JavaScript in `static/js/logout.js` sends a `POST` request to `/api/logout` using the stored session cookie and CSRF token.
+   JavaScript in `static/js/logout.js` sends a `POST` request to `http://identity.cielo.test/logout` using the stored session cookie and CSRF token.
 
 2. **Session Termination**
    The identity provider receives the request and calls Django's `logout()` method to terminate the session.
 
 3. **User Feedback**
    The frontend displays a logout confirmation page (`templates/users/logout.html`).
+
+### Session Verification
+
+Protected pages include a small script (`static/js/session.js`) which runs on load and sends a `GET` request to `http://identity.cielo.test/session`. If the response indicates the user is not authenticated, the browser is redirected to `/users/login/`.
+
+Sessions are stored in a shared cookie scoped to `.cielo.test` so authentication persists across all subdomains.
 
 ### Frontend Role
 

--- a/docs/CieloFrontendTemplateGuide.md
+++ b/docs/CieloFrontendTemplateGuide.md
@@ -2,6 +2,8 @@
 
 This document explains how the `cielo_frontend` Django application is designed and how developers should work within it. The frontend is structured around **Django templates** that render the layout and structure of pages, while **JavaScript is used to dynamically populate content by consuming REST APIs** exposed by backend CIELO services.
 
+The included JavaScript files and templates are illustrative examples. They demonstrate how to interact with the IdentityProvider APIs (`http://identity.cielo.test/login`, `http://identity.cielo.test/logout`, and `http://identity.cielo.test/session`) but can be adapted to suit your needs.
+
 ---
 
 ## 🎯 Purpose of `cielo_frontend`
@@ -91,6 +93,11 @@ All data displayed in templates comes from REST APIs:
 * Authentication is handled via session (set on login)
 * No tokens or API keys are exposed client-side
 * You can use `fetch`, `axios`, or any JS method for API calls
+* Protected pages should verify the active session by calling `http://identity.cielo.test/session` on load and redirect to `/users/login/` if the session is not valid.
+* Core authentication endpoints:
+  * `POST http://identity.cielo.test/login`
+  * `POST http://identity.cielo.test/logout`
+  * `GET  http://identity.cielo.test/session`
 
 ---
 

--- a/docs/SSOIntegrationImplementation.md
+++ b/docs/SSOIntegrationImplementation.md
@@ -1,0 +1,5 @@
+2025-06-02
+
+## SSO Integration Updates
+
+The frontend now verifies the active session on protected pages using `static/js/session.js`. Logout calls the identity provider to terminate the server session and then redirects the user back to the login page. Documentation was updated to clarify API endpoints and usage patterns.


### PR DESCRIPTION
## Summary
- add session validation script
- load session validation on protected pages
- configure logout script to terminate sessions and redirect
- document IdentityProvider endpoints and SSO session flow
- record changes in SSOIntegrationImplementation.md

## Testing
- `make test` *(fails: Django Debug Toolbar can't be used with tests)*

------
https://chatgpt.com/codex/tasks/task_e_683d6532d42c83309cc31b07d556cdc4