### PR TITLE
Fix identity API endpoints

### DIFF
--- a/cielo_frontend/static/js/login.js
+++ b/cielo_frontend/static/js/login.js
@@ -10,7 +10,7 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const formData = new FormData(form);
   const data = Object.fromEntries(formData);
-  const resp = await fetch(`${window.IDENTITY_BASE}/login`, {
+  const resp = await fetch(`${window.IDENTITY_BASE}/api/login`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/cielo_frontend/static/js/logout.js
+++ b/cielo_frontend/static/js/logout.js
@@ -5,7 +5,7 @@ function getCookie(name) {
   return '';
 }
 
-fetch(`${window.IDENTITY_BASE}/logout`, {
+fetch(`${window.IDENTITY_BASE}/api/logout`, {
   method: 'POST',
   headers: {
     'X-CSRFToken': getCookie('csrftoken')

--- a/cielo_frontend/static/js/session.js
+++ b/cielo_frontend/static/js/session.js
@@ -1,6 +1,6 @@
 (async function() {
   try {
-    const resp = await fetch(`${window.IDENTITY_BASE}/session`, {
+    const resp = await fetch(`${window.IDENTITY_BASE}/api/session`, {
       credentials: 'include'
     });
     if (!resp.ok) {

--- a/docs/CieloFrontEndAuthenticationFlow.md
+++ b/docs/CieloFrontEndAuthenticationFlow.md
@@ -8,7 +8,7 @@ This document describes how the CieloFrontend authenticates a user via the Cielo
    The user visits the login page rendered by Django at `/users/login/` (template: `templates/users/login.html`).
 
 2. **JavaScript-Driven API Call**
-   A JavaScript file (`static/js/login.js`) captures the login form submission. It prevents the default form behavior and sends a `POST` request to `http://identity.cielo.test/login`, containing the username and password as JSON. The CSRF token is included in the request header.
+   A JavaScript file (`static/js/login.js`) captures the login form submission. It prevents the default form behavior and sends a `POST` request to `http://identity.cielo.test/api/login`, containing the username and password as JSON. The CSRF token is included in the request header.
 
 3. **Backend Authentication**
    The `/api/login` endpoint is proxied or routed to the `CieloIdentityProvider`, where Django's `AuthenticationService` verifies credentials. If valid, Django's `login()` method creates a session and returns user details.
@@ -19,7 +19,7 @@ This document describes how the CieloFrontend authenticates a user via the Cielo
 ### Logout Flow
 
 1. **Logout Request**
-   JavaScript in `static/js/logout.js` sends a `POST` request to `http://identity.cielo.test/logout` using the stored session cookie and CSRF token.
+   JavaScript in `static/js/logout.js` sends a `POST` request to `http://identity.cielo.test/api/logout` using the stored session cookie and CSRF token.
 
 2. **Session Termination**
    The identity provider receives the request and calls Django's `logout()` method to terminate the session.
@@ -29,7 +29,7 @@ This document describes how the CieloFrontend authenticates a user via the Cielo
 
 ### Session Verification
 
-Protected pages include a small script (`static/js/session.js`) which runs on load and sends a `GET` request to `http://identity.cielo.test/session`. If the response indicates the user is not authenticated, the browser is redirected to `/users/login/`.
+Protected pages include a small script (`static/js/session.js`) which runs on load and sends a `GET` request to `http://identity.cielo.test/api/session`. If the response indicates the user is not authenticated, the browser is redirected to `/users/login/`.
 
 Sessions are stored in a shared cookie scoped to `.cielo.test` so authentication persists across all subdomains.
 

--- a/docs/CieloFrontendTemplateGuide.md
+++ b/docs/CieloFrontendTemplateGuide.md
@@ -2,7 +2,7 @@
 
 This document explains how the `cielo_frontend` Django application is designed and how developers should work within it. The frontend is structured around **Django templates** that render the layout and structure of pages, while **JavaScript is used to dynamically populate content by consuming REST APIs** exposed by backend CIELO services.
 
-The included JavaScript files and templates are illustrative examples. They demonstrate how to interact with the IdentityProvider APIs (`http://identity.cielo.test/login`, `http://identity.cielo.test/logout`, and `http://identity.cielo.test/session`) but can be adapted to suit your needs.
+The included JavaScript files and templates are illustrative examples. They demonstrate how to interact with the IdentityProvider APIs (`http://identity.cielo.test/api/login`, `http://identity.cielo.test/api/logout`, and `http://identity.cielo.test/api/session`) but can be adapted to suit your needs.
 
 ---
 
@@ -93,11 +93,11 @@ All data displayed in templates comes from REST APIs:
 * Authentication is handled via session (set on login)
 * No tokens or API keys are exposed client-side
 * You can use `fetch`, `axios`, or any JS method for API calls
-* Protected pages should verify the active session by calling `http://identity.cielo.test/session` on load and redirect to `/users/login/` if the session is not valid.
+* Protected pages should verify the active session by calling `http://identity.cielo.test/api/session` on load and redirect to `/users/login/` if the session is not valid.
 * Core authentication endpoints:
-  * `POST http://identity.cielo.test/login`
-  * `POST http://identity.cielo.test/logout`
-  * `GET  http://identity.cielo.test/session`
+  * `POST http://identity.cielo.test/api/login`
+  * `POST http://identity.cielo.test/api/logout`
+  * `GET  http://identity.cielo.test/api/session`
 
 ---
 


### PR DESCRIPTION
## Summary
- use `/api` path for login, logout, and session checks
- document the `/api`-prefixed endpoints in frontend guides

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6a826d788330b65d40a421905410