### PR TITLE
Add demo profile TemplateView

### DIFF
--- a/cielo_frontend/templates/users/profile.html
+++ b/cielo_frontend/templates/users/profile.html
@@ -21,18 +21,18 @@
                     <center class="mt-4">
                         {# Placeholder for a profile picture - using an icon for now #}
                         <i class="mdi mdi-account-circle text-muted" style="font-size: 100px;"></i>
-                        <h4 class="card-title mt-2">{{ user.get_full_name|default:user.username }}</h4>
-                        <h6 class="card-subtitle text-muted">{{ user.email }}</h6>
+                        <h4 class="card-title mt-2">{{ profile.first_name }} {{ profile.last_name }}</h4>
+                        <h6 class="card-subtitle text-muted">{{ profile.email }}</h6>
                     </center>
                 </div>
                 <div><hr class="my-0"></div>
                 <div class="card-body">
                     <small class="text-muted">{% translate "Email address" %}</small>
-                    <h6>{{ user.email }}</h6>
+                    <h6>{{ profile.email }}</h6>
                     <small class="text-muted pt-3 db">{% translate "Username" %}</small>
-                    <h6>{{ user.username }}</h6>
+                    <h6>{{ profile.username }}</h6>
                     <small class="text-muted pt-3 db">{% translate "Date Joined" %}</small>
-                    <h6>{{ user.date_joined|date:"N j, Y" }}</h6>
+                    <h6>{{ profile.date_joined }}</h6>
                 </div>
             </div>
         </div>
@@ -46,37 +46,37 @@
                         <div class="form-group row mb-3">
                             <label for="username" class="col-sm-3 text-sm-end control-label col-form-label">{% translate "Username" %}</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" id="username" value="{{ user.username }}" readonly>
+                                <input type="text" class="form-control" id="username" value="{{ profile.username }}" readonly>
                             </div>
                         </div>
                         <div class="form-group row mb-3">
                             <label for="email" class="col-sm-3 text-sm-end control-label col-form-label">{% translate "Email" %}</label>
                             <div class="col-sm-9">
-                                <input type="email" class="form-control" id="email" value="{{ user.email }}" readonly>
+                                <input type="email" class="form-control" id="email" value="{{ profile.email }}" readonly>
                             </div>
                         </div>
                         <div class="form-group row mb-3">
                             <label for="first_name" class="col-sm-3 text-sm-end control-label col-form-label">{% translate "First Name" %}</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" id="first_name" value="{{ user.first_name|default:'' }}" readonly>
+                                <input type="text" class="form-control" id="first_name" value="{{ profile.first_name }}" readonly>
                             </div>
                         </div>
                         <div class="form-group row mb-3">
                             <label for="last_name" class="col-sm-3 text-sm-end control-label col-form-label">{% translate "Last Name" %}</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" id="last_name" value="{{ user.last_name|default:'' }}" readonly>
+                                <input type="text" class="form-control" id="last_name" value="{{ profile.last_name }}" readonly>
                             </div>
                         </div>
                         <div class="form-group row mb-3">
                             <label for="date_joined" class="col-sm-3 text-sm-end control-label col-form-label">{% translate "Date Joined" %}</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" id="date_joined" value="{{ user.date_joined|date:"F j, Y, P" }}" readonly>
+                                <input type="text" class="form-control" id="date_joined" value="{{ profile.date_joined }}" readonly>
                             </div>
                         </div>
                         <div class="form-group row mb-3">
                             <label for="last_login" class="col-sm-3 text-sm-end control-label col-form-label">{% translate "Last Login" %}</label>
                             <div class="col-sm-9">
-                                <input type="text" class="form-control" id="last_login" value="{{ user.last_login|date:"F j, Y, P"|default:'Never' }}" readonly>
+                                <input type="text" class="form-control" id="last_login" value="{{ profile.last_login }}" readonly>
                             </div>
                         </div>
                         <div class="border-top mt-4 pt-3">

--- a/users/urls.py
+++ b/users/urls.py
@@ -6,6 +6,6 @@ app_name = 'users'
 urlpatterns = [
     path('login/', views.user_login, name='login'),
     path('logout/', views.user_logout, name='logout'),
-    path('profile/', views.user_profile, name='profile'),
+    path('profile/', views.UserProfileView.as_view(), name='profile'),
     path('change-password/', views.change_password, name='change_password'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -3,6 +3,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth import update_session_auth_hash
 from django.contrib import messages
+from django.views.generic import TemplateView
+from django.contrib.auth.mixins import LoginRequiredMixin
 
 
 def user_login(request):
@@ -19,33 +21,41 @@ def user_logout(request):
     return render(request, 'users/logout.html')
 
 
-@login_required
-def user_profile(request):
-    """
-    User profile view that displays user information.
-    """
-    context = {
-        'page_title': 'User Profile',
-        'user': request.user,
-        'cielo_navigation_items': [
+class UserProfileView(LoginRequiredMixin, TemplateView):
+    """Demo user profile page."""
+
+    template_name = 'users/profile.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['page_title'] = 'User Profile'
+        # Placeholder data; will come from API calls in the future
+        context['profile'] = {
+            'username': 'jdoe',
+            'email': 'jdoe@example.com',
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'date_joined': 'Jan 1, 2024',
+            'last_login': 'Jan 3, 2024',
+        }
+        context['cielo_navigation_items'] = [
             {
                 'label': 'Dashboard',
                 'url': '/',
-                'icon_class': 'mdi mdi-view-dashboard-outline'
+                'icon_class': 'mdi mdi-view-dashboard-outline',
             },
             {
                 'label': 'Profile',
                 'url': '/users/profile/',
-                'icon_class': 'mdi mdi-account-circle'
+                'icon_class': 'mdi mdi-account-circle',
             },
             {
                 'label': 'Settings',
                 'url': '#',
-                'icon_class': 'mdi mdi-cog-outline'
-            }
+                'icon_class': 'mdi mdi-cog-outline',
+            },
         ]
-    }
-    return render(request, 'users/profile.html', context)
+        return context
 
 
 @login_required


### PR DESCRIPTION
## Summary
- create demo UserProfileView using TemplateView
- route profile URL to the new view
- update profile page to show placeholder data

## Testing
- `python manage.py test` *(fails: The Django Debug Toolbar can't be used with tests)*

------
https://chatgpt.com/codex/tasks/task_e_684707660a1883308314cbdac70aca52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the user profile page to display information using a new approach, resulting in minor changes to how user details are shown.
  - Improved the handling of profile page requests for better maintainability and consistency.
- **Style**
  - Date and time fields on the profile page now display in a raw format without additional formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->